### PR TITLE
Fix APN length marshal/unmarshal in APN Relative Capacity IE

### DIFF
--- a/src/gtpv2/messages/ies/apnrelativecapacity.rs
+++ b/src/gtpv2/messages/ies/apnrelativecapacity.rs
@@ -47,7 +47,7 @@ impl IEs for ApnRelativeCapacity {
         buffer_ie.push(self.ins);
         buffer_ie.push(self.relative_cap);
         let mut z: Vec<u8> = vec![];
-        z.push(self.name.len() as u8);
+        z.push(self.name.len() as u8 + 1);
         for part in self.name.split('.') {
             z.push(part.len() as u8);
             z.extend_from_slice(part.as_bytes());
@@ -74,7 +74,7 @@ impl IEs for ApnRelativeCapacity {
             _ => data.relative_cap = 0,
         }
         let apn_length = buffer[5] as usize;
-        let mut apn_encoded = &buffer[6..=6 + apn_length];
+        let mut apn_encoded = &buffer[6..6 + apn_length];
 
         let mut apn_decoded: Vec<u8> = vec![];
         while apn_decoded.len() < apn_length {
@@ -107,8 +107,8 @@ impl IEs for ApnRelativeCapacity {
 #[test]
 fn apn_rel_cap_ie_marshal_test() {
     let encoded: [u8; 19] = [
-        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0c, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
-        0x63, 0x6f, 0x6d,
+        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0d, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74,
+        0x03, 0x63, 0x6f, 0x6d,
     ];
     let decoded = ApnRelativeCapacity {
         t: APN_REL_CAP,
@@ -125,8 +125,8 @@ fn apn_rel_cap_ie_marshal_test() {
 #[test]
 fn apn_rel_cap_ie_unmarshal_test() {
     let encoded: [u8; 19] = [
-        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0c, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
-        0x63, 0x6f, 0x6d,
+        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0d, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74,
+        0x03, 0x63, 0x6f, 0x6d,
     ];
     let decoded = ApnRelativeCapacity {
         t: APN_REL_CAP,
@@ -136,4 +136,18 @@ fn apn_rel_cap_ie_unmarshal_test() {
         name: "test.net.com".to_string(),
     };
     assert_eq!(ApnRelativeCapacity::unmarshal(&encoded).unwrap(), decoded);
+}
+
+#[test]
+fn apn_rel_cap_ie_marshal_unmarshal_test() {
+    let ie = ApnRelativeCapacity {
+        t: APN_REL_CAP,
+        length: 15,
+        ins: 0,
+        relative_cap: 100,
+        name: "test.net.com".to_string(),
+    };
+    let mut buf = vec![];
+    ie.marshal(&mut buf);
+    assert_eq!(ApnRelativeCapacity::unmarshal(&buf).unwrap(), ie);
 }

--- a/src/gtpv2/messages/ies/apnrelativecapacity.rs
+++ b/src/gtpv2/messages/ies/apnrelativecapacity.rs
@@ -46,13 +46,11 @@ impl IEs for ApnRelativeCapacity {
         buffer_ie.extend_from_slice(&self.length.to_be_bytes());
         buffer_ie.push(self.ins);
         buffer_ie.push(self.relative_cap);
-        let n: Vec<_> = self.name.split('.').collect();
         let mut z: Vec<u8> = vec![];
-        let apn_length: u8 = n.iter().map(|s| s.len() as u8).sum();
-        z.push(apn_length);
-        for i in n.iter() {
-            z.push(i.len() as u8);
-            z.extend_from_slice(i.as_bytes());
+        z.push(self.name.len() as u8);
+        for part in self.name.split('.') {
+            z.push(part.len() as u8);
+            z.extend_from_slice(part.as_bytes());
         }
         buffer_ie.append(&mut z);
         set_tliv_ie_length(&mut buffer_ie);
@@ -110,12 +108,12 @@ impl IEs for ApnRelativeCapacity {
 #[test]
 fn apn_rel_cap_ie_marshal_test() {
     let encoded: [u8; 19] = [
-        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0a, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
+        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0c, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
         0x63, 0x6f, 0x6d,
     ];
     let decoded = ApnRelativeCapacity {
         t: APN_REL_CAP,
-        length: 14,
+        length: 15,
         ins: 0,
         relative_cap: 100,
         name: "test.net.com".to_string(),

--- a/src/gtpv2/messages/ies/apnrelativecapacity.rs
+++ b/src/gtpv2/messages/ies/apnrelativecapacity.rs
@@ -48,6 +48,8 @@ impl IEs for ApnRelativeCapacity {
         buffer_ie.push(self.relative_cap);
         let n: Vec<_> = self.name.split('.').collect();
         let mut z: Vec<u8> = vec![];
+        let apn_length: u8 = n.iter().map(|s| s.len() as u8).sum();
+        z.push(apn_length);
         for i in n.iter() {
             z.push(i.len() as u8);
             z.extend_from_slice(i.as_bytes());
@@ -107,8 +109,8 @@ impl IEs for ApnRelativeCapacity {
 
 #[test]
 fn apn_rel_cap_ie_marshal_test() {
-    let encoded: [u8; 18] = [
-        0xb8, 0x00, 0x0e, 0x00, 0x64, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
+    let encoded: [u8; 19] = [
+        0xb8, 0x00, 0x0f, 0x00, 0x64, 0x0a, 0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6e, 0x65, 0x74, 0x03,
         0x63, 0x6f, 0x6d,
     ];
     let decoded = ApnRelativeCapacity {


### PR DESCRIPTION
There is an additional APN length byte that proceeds the encoded name.
I've also reworked the APN decoding, though this should be probably part of the utils.